### PR TITLE
Gaszaehler Projekt Tags geändert und Beispiel Tags hinzugefügt

### DIFF
--- a/Projekte/JurgenO/GasZaehler.md
+++ b/Projekte/JurgenO/GasZaehler.md
@@ -4,7 +4,7 @@ Desc: Gaszähler mit Anzeige
 ProjectUrl: https://github.com/JurgenO/GasMetering/wiki
 Author: JurgenO
 AuthorUrl: https://github.com/JurgenO
-Tags: OpenSource, Sensor, Batterie
+Tags: OpenSource, Sensor, 230V
 Thumb: GasZaehler.jpg
 Added: 2022-12-28
 ---

--- a/Projekte/JurgenO/GasZaehler.md
+++ b/Projekte/JurgenO/GasZaehler.md
@@ -4,7 +4,7 @@ Desc: Gaszähler mit Anzeige
 ProjectUrl: https://github.com/JurgenO/GasMetering/wiki
 Author: JurgenO
 AuthorUrl: https://github.com/JurgenO
-Tags: OpenSource, Sensor, 230V
+Tags: OpenSource, Sensor, 230V, Display
 Thumb: GasZaehler.jpg
 Added: 2022-12-28
 ---

--- a/Projekte/Projekt-hinzufuegen.md
+++ b/Projekte/Projekt-hinzufuegen.md
@@ -58,4 +58,10 @@ Ein Beispiel hierfür ist [HM-LC-Dim1PWM](https://github.com/jp112sdl/AskSinPPCo
 Bei der Wahl der Tags sollte sich vor allem an den schon vorhandenen Schlagworten orientiert werden.
 Tags, die auf alle Projekte zutreffend sind zu vermeiden (Bsp. Homematic, AskSinPP). Natürlich können
 neue Tags hinzugefügt werden sofern dies Sinn ergibt. Sie werden automatisch in die Filterleiste mit
-aufgenommen.
+aufgenommen. 
+
+Beipiele für Tags:  
+* Sensor, Aktor, Dimmer, Taster etc.
+* Temperatur, Visualisierung, LED etc.
+* Batterie, 230V etc.
+


### PR DESCRIPTION
Hallo nochmal,
das Gaszaehler Projekt läuft wegen des OLED Diplays tatsächlich auf 230V. Deshalb habe ich den Tag "Batterie" durch "230V" ersetzt.

Beispiel-Tags habe ich in der allgemeinen Beschreibung wie man Projekte hinzufügt aufgelistet.

Gruss aus Straelen
Juergen