### PR TITLE
fix of wrong description

### DIFF
--- a/Projekte/FUEL4EP/HB-UNI-SenAct-4-4-SC_DS.md
+++ b/Projekte/FUEL4EP/HB-UNI-SenAct-4-4-SC_DS.md
@@ -1,6 +1,6 @@
 ---
 isProject: true
-Desc: 3x Schalter für Betrieb an Netzfreischalter Filter Autokalibrierung, rLF Version
+Desc: 3x Schalter für Betrieb an Netzfreischalter 
 ProjectUrl: https://github.com/FUEL4EP/HomeAutomation/tree/master/AsksinPP_developments/sketches/HB-UNI-SenAct-4-4-SC_DS
 Author: FUEL4EP
 AuthorUrl: https://github.com/FUEL4EP


### PR DESCRIPTION
Sorry, I did a copy paste error in my previous pull request.

Is there a length limitation of a project name?

The final '_' of HB-UNI-Sensor1-AQ-BME680_KF_rLF is missing at the web page